### PR TITLE
Fix failing tests for ().raw function

### DIFF
--- a/src/cmd.js
+++ b/src/cmd.js
@@ -191,6 +191,8 @@
         Command.prototype.__defineGetter__(name, function () {
             return fn;
         });
+		
+		return cmd[name];
     };
 
     /**
@@ -222,7 +224,7 @@
             if (!self.fn) {
                 throw new Error('Inappropriate place to call .raw()')
             }
-            return self.fn([value])[0];
+            return self.fn(Array.isArray(value) ? value : [value])[0];
         };
     });
 


### PR DESCRIPTION
fix for failing tests caused by the ().raw function that's added to each type commands.
().raw was not returning correct unwrapped value given an array of values as input
